### PR TITLE
Abstract for Gamma 2016 poster contribution

### DIFF
--- a/abstract.txt
+++ b/abstract.txt
@@ -1,10 +1,14 @@
 Open data formats and software for gamma-ray astronomy
 ======================================================
 
-Authors: tbd
+Authors: Christoph Deil, Jeremy Perkins, Catherine Boisson, Johannes King, Peter
+Eger, Michael Mayer, Matthew Wood, Victor Zabalza, Jürgen Knödlseder, Tarek
+Hassan, Lars Mohrmann, Alexander Ziegler, Bruno Khelifi, Daniela Dorner, Gernot
+Maier, Giovanna Pedaletti, Jaime Rosado, José Luis Contreras, Julien Lefaucheur,
+Kai Brügge, Mathieu Servillat, Régis Terrier, Roland Walter, Saverio Lombardi
 
-In gamma-ray astronomy, a variety of data formats and proprietary software exist,
-developed for one specific mission or experiment. Especially in
+In gamma-ray astronomy, a variety of data formats and proprietary software
+exist, developed for one specific mission or experiment. Especially in
 ground-based gamma-ray astronomy, imaging atmospheric Cherenkov telescope (IACT)
 data and software has been private to the collaborations operating the
 telescopes. There is a general movement in science towards open data and
@@ -18,6 +22,6 @@ first face-to-face meeting on IACT high-level data model and formats took place
 in April 2016 in Meudon. We hope that this open multi-mission effort will help
 accelerate the development of open data formats and open-source software for
 gamma-ray astronomy, leading to synergies in the development of analysis codes
-and eventually better scientific results (reproducible, multi-mission). This poster
-will summarise what we have done so far and has the goal to solicit comments and
-future contributions from the gamma-ray astronomy community.
+and eventually better scientific results (reproducible, multi-mission). This
+poster will summarise what we have done so far and has the goal to solicit
+comments and future contributions from the gamma-ray astronomy community.

--- a/abstract.txt
+++ b/abstract.txt
@@ -1,0 +1,23 @@
+Open data formats and software for gamma-ray astronomy
+======================================================
+
+Authors: tbd
+
+In gamma-ray astronomy, a lot of proprietary data formats and software exist
+that were developed for one specific mission or experiment. Especially in
+ground-based gamma-ray astronomy, imaging atmospheric Cherenkov telescope (IACT)
+data and software until now was private to the collaborations operating the
+telescopes. There is a general movement in science towards open data and
+software and specifically the next big IACT, the Cherenkov telescope array (CTA)
+will be operated as an open observatory.
+
+We have created a Github organisation at https://github.com/open-gamma-ray-astro
+where we are developing data format specifications. A public mailing list was
+set up at https://lists.nasa.gov/mailman/listinfo/open-gamma-ray-astro and a
+first face-to-face meeting on IACT high-level data model and formats took place
+in April 2016 in Meudon. We hope that this open multi-mission effort will help
+accelerate the development of open data formats and open-source software for
+gamma-ray astronomy, leading to synergies in the development of analysis codes
+and eventually better science results (reproducible, multi-mission). This poster
+will summarise what we have done so far and hopefully will solicit comments or
+future contributions from the gamma-ray astronomy community.

--- a/abstract.txt
+++ b/abstract.txt
@@ -3,12 +3,12 @@ Open data formats and software for gamma-ray astronomy
 
 Authors: tbd
 
-In gamma-ray astronomy, a lot of proprietary data formats and software exist
-that were developed for one specific mission or experiment. Especially in
+In gamma-ray astronomy, a variety of data formats and proprietary software exist,
+developed for one specific mission or experiment. Especially in
 ground-based gamma-ray astronomy, imaging atmospheric Cherenkov telescope (IACT)
-data and software until now was private to the collaborations operating the
+data and software has been private to the collaborations operating the
 telescopes. There is a general movement in science towards open data and
-software and specifically the next big IACT, the Cherenkov telescope array (CTA)
+software and specifically the next big IACT, the Cherenkov Telescope Array (CTA)
 will be operated as an open observatory.
 
 We have created a Github organisation at https://github.com/open-gamma-ray-astro
@@ -18,6 +18,6 @@ first face-to-face meeting on IACT high-level data model and formats took place
 in April 2016 in Meudon. We hope that this open multi-mission effort will help
 accelerate the development of open data formats and open-source software for
 gamma-ray astronomy, leading to synergies in the development of analysis codes
-and eventually better science results (reproducible, multi-mission). This poster
-will summarise what we have done so far and hopefully will solicit comments or
+and eventually better scientific results (reproducible, multi-mission). This poster
+will summarise what we have done so far and has the goal to solicit comments and
 future contributions from the gamma-ray astronomy community.


### PR DESCRIPTION
I would like to make a poster for the Gamma 2016 conference to advertise the open-gamma-ray-astro effort to the gamma-ray community.

The conference is July 11-15, 2016 in Heidelberg.
Abstract submission deadline is May 22.
https://www.mpi-hd.mpg.de/hd2016/

cc @kialio @woodmd @cboisson @joleroi @jknodlseder @TarekHC

This is a pull request with the title and abstract. Please review and comment now.

I'll make a first proposal for the poster later and we can then use that as the starting point for discussions on content. Also we can decide whether to write a proceeding on this or not later.

For co-authors, my suggestion would be:
1. Put everyone that has made a contribution to the open spec or was present at the IACT DL3 meeting in Meudon and give them the option to opt-out.
2. Invite everyone on the [open-gamma-ray-astro](https://lists.nasa.gov/mailman/listinfo/open-gamma-ray-astro) to co-author, i.e. make it opt-in for them (75 people).
